### PR TITLE
Remove some kwargs for cleaner error stacks

### DIFF
--- a/check_version.py
+++ b/check_version.py
@@ -1,7 +1,8 @@
 import re
 import subprocess
+
 _METADATA = dict(re.findall(r'__([a-z]+)__\s*=\s*"([^"]+)"', open("deepr/version.py").read()))
-version = _METADATA['version']
+version = _METADATA["version"]
 process = subprocess.Popen(["git", "describe", "--tags"], stdout=subprocess.PIPE)
 tagged_version = process.communicate()[0].strip().decode(encoding="utf-8")
 if version == tagged_version:

--- a/deepr/hooks/steps_per_sec.py
+++ b/deepr/hooks/steps_per_sec.py
@@ -35,9 +35,14 @@ class StepsPerSecHook(tf.train.StepCounterHook):
         use_mlflow: bool = False,
         use_graphite: bool = False,
         skip_after_step: int = None,
-        **kwargs,
+        every_n_steps: int = 100,
+        every_n_secs: int = None,
+        output_dir: str = None,
+        summary_writer=None,
     ):
-        super().__init__(**kwargs)
+        super().__init__(
+            every_n_steps=every_n_steps, every_n_secs=every_n_secs, output_dir=output_dir, summary_writer=summary_writer
+        )
         self.batch_size = batch_size
         self.name = name
         self.use_mlflow = use_mlflow

--- a/deepr/hooks/summary.py
+++ b/deepr/hooks/summary.py
@@ -10,9 +10,21 @@ from deepr.hooks.base import TensorHookFactory
 class SummarySaverHookFactory(TensorHookFactory):
     """Summary Saver Hook"""
 
-    def __init__(self, tensors: List[str] = None, **kwargs):
+    def __init__(
+        self,
+        tensors: List[str] = None,
+        save_steps: int = None,
+        save_secs: int = None,
+        output_dir: str = None,
+        summary_writer=None,
+        scaffold=None,
+    ):
         self.tensors = tensors
-        self._kwargs = kwargs
+        self.save_steps = save_steps
+        self.save_secs = save_secs
+        self.output_dir = output_dir
+        self.summary_writer = summary_writer
+        self.scaffold = scaffold
 
     def __call__(self, tensors: Dict[str, tf.Tensor]) -> tf.estimator.SessionRunHook:
         # Extract relevant tensors
@@ -25,4 +37,11 @@ class SummarySaverHookFactory(TensorHookFactory):
         for name, tensor in tensors.items():
             tf.summary.scalar(name, tensor)
 
-        return tf.train.SummarySaverHook(summary_op=tf.summary.merge_all(), **self._kwargs)
+        return tf.train.SummarySaverHook(
+            save_steps=self.save_steps,
+            save_secs=self.save_secs,
+            output_dir=self.output_dir,
+            summary_writer=self.summary_writer,
+            scaffold=self.scaffold,
+            summary_op=tf.summary.merge_all(),
+        )

--- a/deepr/jobs/trainer.py
+++ b/deepr/jobs/trainer.py
@@ -25,8 +25,8 @@ class TrainSpec(dict):
 class EvalSpec(dict):
     """Named Dict for EvalSpec arguments with reasonable defaults."""
 
-    def __init__(self, steps: int = None, start_delay_secs: int = 120, throttle_secs: int = 100, **kwargs):
-        super().__init__(steps=steps, start_delay_secs=start_delay_secs, throttle_secs=throttle_secs, **kwargs)
+    def __init__(self, steps: int = None, name: str = None, start_delay_secs: int = 120, throttle_secs: int = 100):
+        super().__init__(steps=steps, name=name, start_delay_secs=start_delay_secs, throttle_secs=throttle_secs)
 
 
 class ConfigProto(dict):

--- a/deepr/prepros/core.py
+++ b/deepr/prepros/core.py
@@ -63,15 +63,15 @@ class Map(base.Prepro):
     ----------
     map_func : Callable[[Any], Any]
         Function to map to each element
+    modes : Iterable[str], Optional
+        Active modes for the map (will skip modes not in modes).
+        Default is None (all modes are considered active modes).
+    num_parallel_calls : int
+        Number of threads.
     on_dict : bool
         If True (default), assumes dataset yields dictionaries
     update : bool
         If True (default), combine element and map_func(element)
-    modes : Iterable[str], Optional
-        Active modes for the map (will skip modes not in modes).
-        Default is None (all modes are considered active modes).
-    **kwargs :
-        Optional keyword arguments to pass to tf.data.Dataset.map
     """
 
     def __init__(
@@ -197,11 +197,18 @@ class Shuffle(base.Prepro):
         Default is None (all modes are considered active modes).
     """
 
-    def __init__(self, buffer_size: int, modes: Iterable[str] = None, **kwargs):
+    def __init__(
+        self,
+        buffer_size: int,
+        modes: Iterable[str] = None,
+        seed: tf.int64 = None,
+        reshuffle_each_iteration: bool = None,
+    ):
         super().__init__()
         self.buffer_size = buffer_size
         self.modes = modes
-        self._kwargs = kwargs
+        self.seed = seed
+        self.reshuffle_each_iteration = reshuffle_each_iteration
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.buffer_size})"
@@ -210,7 +217,7 @@ class Shuffle(base.Prepro):
         if mode is not None and self.modes is not None and mode not in self.modes:
             LOGGER.info(f"Not applying {self} (mode={mode})")
             return dataset
-        return dataset.shuffle(self.buffer_size, **self._kwargs)
+        return dataset.shuffle(self.buffer_size, seed=self.seed, reshuffle_each_iteration=self.reshuffle_each_iteration)
 
 
 class Repeat(base.Prepro):

--- a/deepr/prepros/record.py
+++ b/deepr/prepros/record.py
@@ -11,10 +11,10 @@ from deepr.prepros import base
 class TFRecordSequenceExample(base.Prepro):
     """Parse TF Record Sequence Example"""
 
-    def __init__(self, fields: List[Field], **kwargs):
+    def __init__(self, fields: List[Field], num_parallel_calls: int = None):
         super().__init__()
         self.fields = fields
-        self._kwargs = kwargs
+        self.num_parallel_calls = num_parallel_calls
 
     @property
     def parse_fn(self):
@@ -34,4 +34,4 @@ class TFRecordSequenceExample(base.Prepro):
         return _parse_func
 
     def apply(self, dataset: tf.data.Dataset, mode: str = None):
-        return dataset.map(self.parse_fn, **self._kwargs)
+        return dataset.map(self.parse_fn, num_parallel_calls=self.num_parallel_calls)

--- a/deepr/readers/record.py
+++ b/deepr/readers/record.py
@@ -9,16 +9,18 @@ from deepr.io.path import Path
 
 
 class TFRecordReader(base.Reader):
-    """Class for TFRecord Reader of tf.train.Example
+    """Class for TFRecord Reader of tf.train.Example.
 
     Attributes
     ----------
-    buffer_size : int, Optional
-        If not None, shuffle filenames
-    path : List[Union[str, Path]]
-        List of filenames or path to directory
+    num_parallel_calls : TYPE
+        Description
     num_parallel_reads : int
         Number of parallel reads
+    path : List[Union[str, Path]]
+        List of filenames or path to directory
+    shuffle : bool
+        Shuffle files if True before reading.
     """
 
     def __init__(
@@ -27,14 +29,12 @@ class TFRecordReader(base.Reader):
         num_parallel_reads: int = 8,
         num_parallel_calls: int = 8,
         shuffle: bool = True,
-        **kwargs
     ):
         super().__init__()
         self.path = path
         self.num_parallel_reads = num_parallel_reads
         self.num_parallel_calls = num_parallel_calls
         self.shuffle = shuffle
-        self._kwargs = kwargs
 
     @property
     def filenames(self):

--- a/deepr/utils/graphite.py
+++ b/deepr/utils/graphite.py
@@ -22,7 +22,16 @@ INTERVAL_ENV_VAR = "GRAPHITE_INTERVAL"
 
 @handle_exceptions
 def get_sender(
-    host: str = None, port: int = None, prefix: str = None, postfix: str = None, interval: int = None, **kwargs
+    host: str = None,
+    port: int = None,
+    prefix: str = None,
+    postfix: str = None,
+    timeout: int = 5,
+    interval: int = None,
+    queue_size: int = None,
+    log_sends: bool = False,
+    protocol: str = "tcp",
+    batch_size: int = 1000,
 ):
     """Get Graphite Sender."""
     # Retrieve parameters from environment variables
@@ -33,7 +42,17 @@ def get_sender(
 
     # Return sender
     prefix = f"{prefix}.{postfix}" if postfix else prefix
-    return graphyte.Sender(host=host, port=port, prefix=prefix, interval=interval, **kwargs)
+    return graphyte.Sender(
+        host=host,
+        port=port,
+        prefix=prefix,
+        timeout=timeout,
+        interval=interval,
+        queue_size=queue_size,
+        log_sends=log_sends,
+        protocol=protocol,
+        batch_size=batch_size,
+    )
 
 
 @handle_exceptions

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,7 @@ _INSTALL_REQUIRES = [
     "skein>=0.8",
 ]
 
-_EXTRAS_REQUIRE = {
-    "cpu": ["tensorflow>=1.15,<2"],
-    "gpu": ["tensorflow-gpu>=1.15,<2"],
-}
+_EXTRAS_REQUIRE = {"cpu": ["tensorflow>=1.15,<2"], "gpu": ["tensorflow-gpu>=1.15,<2"]}
 
 _TEST_REQUIRE = ["pytest"]
 


### PR DESCRIPTION
I did not update the layers module, because what should be done is not obvious.
One possibility would be to use the decorator as much as possible. This would make the code cleaner. However, IDEs and pylint can get confused (missing arguments since the decorator produces a class from a function), so maybe not a great idea.
One other possibility is to replace all **kwargs by `name`, `inputs`, etc. when relevant.
Another possibility is not to touch it.