### PR TITLE
add links in notebooks

### DIFF
--- a/docs/getting_started/advanced.ipynb
+++ b/docs/getting_started/advanced.ipynb
@@ -175,12 +175,12 @@
     "\n",
     "For training, let's add\n",
     "\n",
-    "- `LoggingTensorHookFactory` : log additional metrics, optionaly send to MLFlow / Graphite\n",
-    "- `SummarySaverHookFactory` : save summaries for Tensorboard\n",
-    "- `NumParamsHook` : log initial number of parameters in the model\n",
-    "- `LogVariablesInitHook` : log some basic stats about initial parameters (number of zeros, average norm)\n",
-    "- `StepsPerSecHook` : log training speed (number of batches and examples per second)\n",
-    "- `EarlyStoppingHookFactory` : stop training if the `loss` does not decrease on the validation set of 100 consecutive training steps.\n",
+    "- [LoggingTensorHookFactory](https://criteo.github.io/deepr/API/_autosummary/deepr.hooks.LoggingTensorHookFactory.html) : log additional metrics, optionaly send to MLFlow / Graphite\n",
+    "- [SummarySaverHookFactory](https://criteo.github.io/deepr/API/_autosummary/deepr.hooks.SummarySaverHookFactory.html) : save summaries for Tensorboard\n",
+    "- [NumParamsHook](https://criteo.github.io/deepr/API/_autosummary/deepr.hooks.NumParamsHook.html) : log initial number of parameters in the model\n",
+    "- [LogVariablesInitHook](https://criteo.github.io/deepr/API/_autosummary/deepr.hooks.LogVariablesInitHook.html) : log some basic stats about initial parameters (number of zeros, average norm)\n",
+    "- [StepsPerSecHook](https://criteo.github.io/deepr/API/_autosummary/deepr.hooks.StepsPerSecHook.html) : log training speed (number of batches and examples per second)\n",
+    "- [EarlyStoppingHookFactory](https://criteo.github.io/deepr/API/_autosummary/deepr.hooks.EarlyStoppingHookFactory.html) : stop training if the `loss` does not decrease on the validation set of 100 consecutive training steps.\n",
     "\n",
     "For evaluation and final evaluation, let's just add a `LoggingTensorHookFactory` to log the metrics values and optionaly send them to MLFlow Graphite (with the `use_mlflow` and `use_graphite` arguments)"
    ]
@@ -333,7 +333,7 @@
     "- also, it might contain parts of the graph that are not actually useful for inference.\n",
     "- finally, maybe the actual inputs of our graph will be intermediate nodes. For example, in NLP, if we have fine-tuned some embeddings and they are part of the graph, the `SavedModel` probably will expect the word indices. However, in a deployment scenario, the service producing embeddings might be independent from our model. In other words, during training, the graph inputs were the word indices. During inference, the graph inputs are the actual embeddings.\n",
     "\n",
-    "We can do some of these optimizations using the `OptimizeSavedModel` job.\n",
+    "We can do some of these optimizations using the [OptimizeSavedModel](https://criteo.github.io/deepr/API/_autosummary/deepr.jobs.OptimizeSavedModel.html#deepr.jobs.OptimizeSavedModel) job.\n",
     "\n",
     "It produces one self-contained file (a `.pb` file, like the `SavedModel`), that contains an updated version of the graph (only the part that produces some tensor `fetch` given some other tensors `feeds`), makes it possible to update the tensor's names, and adds the variable values directly inside the graph definition (effectively making them constants).\n",
     "\n",
@@ -471,6 +471,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.8"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/quickstart.ipynb
+++ b/docs/getting_started/quickstart.ipynb
@@ -15,41 +15,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook is a gentle introduction to the few concepts and abstractions of deepr_python.\n",
+    "This notebook is a gentle introduction to the few concepts and abstractions of deepr.\n",
     "\n",
     "It demonstrates how to train a model that learns how to multiply a number by 2.\n",
     "\n",
-    "The reference documentation can be found at http://go/nndoc.\n",
+    "To train a model with deepr the main entry point is the [Trainer](https://criteo.github.io/deepr/API/_autosummary/deepr.jobs.Trainer.html#deepr.jobs.Trainer) job.\n",
     "\n",
-    "To train a model with deepr-python the main entry point is the [Trainer](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/_modules/deepr_python/core/jobs/trainer.html#Trainer) job.\n",
+    "It is important at this point to stress that `deepr` is not yet another library to build neural networks, but merely a utility to build functions that operate on basic Tensorflow types, i.e. [tf.Tensor](https://www.tensorflow.org/api_docs/python/tf/Tensor) and [tf.data.Dataset](https://www.tensorflow.org/api_docs/python/tf/data/Dataset).\n",
     "\n",
-    "It is important at this point to stress that `deepr_python` is not yet another library to build neural networks, but merely a utility to build functions that operate on basic Tensorflow types, i.e. `tf.Tensor` and `tf.data.Dataset`.\n",
+    "Using functional programming makes it easy to lazily define graphs that will only be built at run time by the [tf.estimator](https://www.tensorflow.org/guide/estimator) high-level API.\n",
     "\n",
-    "Using functional programming makes it easy to lazily define graphs that will only be built at run time by the `tf.estimator` high-level API.\n",
-    "\n",
-    "The `Trainer` job uses most of the [important concepts](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/CORE_API.html) of deepr-python, while only expecting basic types (mainly functions operating on datasets, dictionaries of tensors, etc.).\n",
+    "The `Trainer` job uses most of the [important concepts](https://criteo.github.io/deepr/API/core.html) of deepr, while only expecting basic types (mainly functions operating on datasets, dictionaries of tensors, etc.).\n",
     "\n",
     "\n",
     "* `path_model : str`\n",
     "    Path to the model directory. Can be either local or HDFS.\n",
     "    \n",
     "* `pred_fn : Callable[[Dict[str, tf.Tensor], str], Dict[str, tf.Tensor]]`\n",
-    "    Typically a `Layer` instance, but in general, any callable.\n",
+    "    Typically a [Layer](https://criteo.github.io/deepr/API/_autosummary/deepr.layers.Layer.html#deepr.layers.Layer) instance, but in general, any callable.\n",
     "\n",
     "* `loss_fn : Callable[[Dict[str, tf.Tensor], str], Dict[str, tf.Tensor]]`\n",
-    "    Typically a `Layer` instance, but in general, any callable.\n",
+    "    Typically a [Layer](https://criteo.github.io/deepr/API/_autosummary/deepr.layers.Layer.html#deepr.layers.Layer) instance, but in general, any callable.\n",
     "\n",
     "* `optimizer_fn : Callable[[tf.Tensor], tf.Tensor]`\n",
-    "    Typically an `Optimizer` instance, but in general, any callable.\n",
+    "    Typically an [Optimizer](https://criteo.github.io/deepr/API/_autosummary/deepr.optimizers.Optimizer.html#deepr.optimizers.Optimizer) instance, but in general, any callable.\n",
     "\n",
     "* `train_input_fn : Callable[[], tf.data.Dataset]`\n",
-    "    Typically a `Reader` instance, but in general, any callable.\n",
+    "    Typically a [Reader](https://criteo.github.io/deepr/API/_autosummary/deepr.readers.Reader.html#deepr.readers.Reader) instance, but in general, any callable.\n",
     "\n",
     "* `eval_input_fn : Callable[[], tf.data.Dataset]`\n",
-    "    Typically a `Reader` instance, but in general, any callable.\n",
+    "    Typically a [Reader](https://criteo.github.io/deepr/API/_autosummary/deepr.readers.Reader.html#deepr.readers.Reader) instance, but in general, any callable.\n",
     "\n",
     "* `prepro_fn: Callable[[tf.data.Dataset, str], tf.data.Dataset], Optional`\n",
-    "    Typically a `Prepro` instance, but in general, any callable.\n",
+    "    Typically a [Prepro](https://criteo.github.io/deepr/API/_autosummary/deepr.prepros.Prepro.html#deepr.prepros.Prepro) instance, but in general, any callable.\n",
     "\n",
     "There are more parameters that use the other concepts (hooks, metrics, exporter, ...) and this will be covered in another guide.\n",
     "\n",
@@ -69,7 +67,7 @@
    "source": [
     "The first step is to build a dataset. For this we will build a synthetic dataset of numbers of (x, 2x).\n",
     "\n",
-    "Also see other ways to build a dataset in the [reader reference](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/CORE_API.html#reader)"
+    "Also see other ways to build a dataset in the [reader reference](https://criteo.github.io/deepr/API/core.html#reader)"
    ]
   },
   {
@@ -107,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's define a generator function and then use a [GeneratorReader](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/_autosummary/deepr.readers.GeneratorReader.html?highlight=generatorreader) to create a `tf.data.Dataset`"
+    "Let's define a generator function and then use a [GeneratorReader](https://criteo.github.io/deepr/API/_autosummary/deepr.readers.GeneratorReader.html#deepr.readers.GeneratorReader) to create a `tf.data.Dataset`"
    ]
   },
   {
@@ -233,7 +231,7 @@
     "\n",
     "Let's use the `prepro` module to functionally define a preprocessing function.\n",
     "\n",
-    "See the [prepro reference](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/CORE_API.html#prepro)"
+    "See the [prepro reference](https://criteo.github.io/deepr/API/core.html#prepro)"
    ]
   },
   {
@@ -335,7 +333,7 @@
     "\n",
     "We're going to use the `layer` module to quickly define those functions.\n",
     "\n",
-    "Make sure to check the [layer reference](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/CORE_API.html#layer) for more information."
+    "Make sure to check the [layer reference](https://criteo.github.io/deepr/API/core.html#layer) for more information."
    ]
   },
   {
@@ -414,7 +412,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The power of the base `Layer` class is that layers are actually functions that can operate on both dictionaries and tuples of tensors.\n",
+    "The power of the base [Layer](https://criteo.github.io/deepr/API/_autosummary/deepr.layers.Layer.html#deepr.layers.Layer) class is that layers are actually functions that can operate on both dictionaries and tuples of tensors.\n",
     "\n",
     "The `inputs` and `outputs` arguments, when given, specify the keys of the dictionaries to use for the layer.\n",
     "\n",
@@ -543,7 +541,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The last thing we need is the optimizer. See the [optimizer reference](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/CORE_API.html#optimizer)"
+    "The last thing we need is the optimizer. See the [optimizer reference](https://criteo.github.io/deepr/API/core.html#optimizer)"
    ]
   },
   {
@@ -568,7 +566,7 @@
    "source": [
     "Since all these concepts are now defined, let's create a `Trainer` job. \n",
     "\n",
-    "Make sure to check the [trainer reference](http://mozart-rbeaumont-default.service.am6.consul.prod.crto.in:8000/_autosummary/deepr.jobs.Trainer.html)"
+    "Make sure to check the [trainer reference](https://criteo.github.io/deepr/API/_autosummary/deepr.jobs.Trainer.html#deepr.jobs.Trainer)"
    ]
   },
   {
@@ -670,10 +668,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
+    "source": [],
     "metadata": {
      "collapsed": false
-    },
-    "source": []
+    }
    }
   }
  },

--- a/docs/getting_started/tuning.ipynb
+++ b/docs/getting_started/tuning.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Hyper Parameter Tuning\n",
     "\n",
-    "This notebook builds upon the previous [pipeline example](.pipline.iypnb). The goal is to perform hyperparameter search by varying the learning rate and batch size.\n",
+    "This notebook builds upon the previous [pipeline example](https://criteo.github.io/deepr/getting_started/pipeline.html). The goal is to perform hyperparameter search by varying the learning rate and batch size.\n",
     "\n",
     "To launch an HP search, the steps are\n",
     "\n",
@@ -336,6 +336,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.8"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
there is no simple way to do this better in markdown cells
read https://github.com/gammapy/gammapy/issues/2175 for more information

to do references without link to pages, we would need to use in one way or another restructured text to generate the notebooks

I think these absolute links have at least one benefit : the links are clickable when using the notebooks

# Description

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Release


## Checklist

- [x] I have followed the [CONTRIBUTING](https://github.com/criteo/deepr/blob/master/docs/CONTRIBUTING.rst) guidelines.
- [x] I have updated the [CHANGELOG](https://github.com/criteo/deepr/blob/master/docs/CHANGELOG.rst).
