### PR TITLE
Fix wrong argument order in YarnConfig upload_zip_to_hdfs

### DIFF
--- a/deepr/jobs/yarn_config.py
+++ b/deepr/jobs/yarn_config.py
@@ -81,7 +81,7 @@ def upload_pex(
         )
     elif not Path(path_pex_existing).is_hdfs:
         LOGGER.info(f"Uploading env to {path_pex}")
-        packaging.upload_zip_to_hdfs(path_pex, archive_on_hdfs=path_pex_existing)
+        packaging.upload_zip_to_hdfs(path_pex_existing, archive_on_hdfs=path_pex)
     else:
         LOGGER.info(f"Skipping upload, PEX {path_pex_existing} already exists")
         path_pex = path_pex_existing

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,8 @@ Removed
 ~~~~~~~
 Fixed
 ~~~~~
+- wrong arguments in ``YarnConfig`` for ``upload_zip_to_hdfs``.
+
 Security
 ~~~~~~~~
 


### PR DESCRIPTION
# Description

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Release


## Checklist

- [x] I have followed the [CONTRIBUTING](https://github.com/criteo/deepr/blob/master/docs/CONTRIBUTING.rst) guidelines.
- [x] I have updated the [CHANGELOG](https://github.com/criteo/deepr/blob/master/docs/CHANGELOG.rst).
