### PR TITLE
Add metric name sanitizer.

### DIFF
--- a/deepr/hooks/logging_tensor.py
+++ b/deepr/hooks/logging_tensor.py
@@ -9,6 +9,7 @@ import tensorflow as tf
 from deepr.hooks.base import TensorHookFactory
 from deepr.utils import mlflow
 from deepr.utils import graphite
+from deepr.metrics import sanitize_metric_name
 
 
 LOGGER = logging.getLogger(__name__)
@@ -140,7 +141,7 @@ class LoggingTensorHook(tf.train.LoggingTensorHook):
                 graphite.log_metric(tag, value, postfix=self.name)
             if self.use_mlflow:
                 tag = tag if self.name is None else f"{self.name}_{tag}"
-                mlflow.log_metric(tag, value, step=global_step)
+                mlflow.log_metric(sanitize_metric_name(tag), value, step=global_step)
 
 
 _UNIT_TO_FACTOR = {"kb": 1024, "mb": 1024 ** 2, "gb": 1024 ** 3}

--- a/deepr/metrics/__init__.py
+++ b/deepr/metrics/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=unused-import,missing-docstring
 
-from deepr.metrics.base import Metric
+from deepr.metrics.base import Metric, sanitize_metric_name
 from deepr.metrics.core import LastValue, MaxValue
 from deepr.metrics.step import StepCounter
 from deepr.metrics.mean import Mean, FiniteMean, DecayMean

--- a/deepr/metrics/base.py
+++ b/deepr/metrics/base.py
@@ -13,9 +13,31 @@ class Metric(ABC):
         raise NotImplementedError()
 
 
+def sanitize_metric_name(name: str) -> str:
+    """Sanitize scope/variable name for tensorflow and mlflow
+
+    This is needed as sometimes variables automatically created while
+    building layers contain forbidden characters
+    >>> from tensorflow.python.framework.ops import _VALID_SCOPE_NAME_REGEX as TF_VALID_REGEX
+    >>> from mlflow.utils.validation import _VALID_PARAM_AND_METRIC_NAMES as MLFLOW_VALID_REGEX
+    >>> from deepr.metrics import sanitize_metric_name
+    >>> kernel_variable_name = 'my_layer/kernel:0'
+    >>> bool(TF_VALID_REGEX.match(kernel_variable_name))
+    False
+    >>> bool(MLFLOW_VALID_REGEX.match(kernel_variable_name))
+    False
+    >>> bool(TF_VALID_REGEX.match(sanitize_metric_name(kernel_variable_name)))
+    True
+    >>> bool(MLFLOW_VALID_REGEX.match(sanitize_metric_name(kernel_variable_name)))
+    True
+    """
+    name = name.replace(":", "-")
+    return name
+
+
 def get_metric_variable(name: str, shape: Tuple, dtype):
     return tf.get_variable(
-        name=name,
+        name=sanitize_metric_name(name),
         shape=shape,
         dtype=dtype,
         initializer=tf.constant_initializer(value=0),

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -22,6 +22,7 @@ Removed
 Fixed
 ~~~~~
 Doctests were fixed.
+Add metric name sanitizer, especially needed to sanitize keras built variable names.
 
 Security
 ~~~~~~~~


### PR DESCRIPTION
This comes from the need to safely manipulate tensor names generated by keras.

# Description

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Release


## Checklist

- [x] I have followed the [CONTRIBUTING](https://github.com/criteo/deepr/blob/master/docs/CONTRIBUTING.rst) guidelines.
- [x] I have updated the [CHANGELOG](https://github.com/criteo/deepr/blob/master/docs/CHANGELOG.rst).
