### PR TITLE
add a delete_dir function in path.py and use it in copy_dir to overwrite the target directory by default

### DIFF
--- a/deepr/io/path.py
+++ b/deepr/io/path.py
@@ -131,6 +131,19 @@ class Path:
             else:
                 pathlib.Path(str(self)).mkdir(parents=parents, exist_ok=exist_ok)
 
+    def delete_dir(self, filesystem: FileSystem = None):
+        """Delete dir from filesystem"""
+        if not self.is_dir(filesystem=filesystem):
+            raise FileNotFoundError(str(self))
+        if filesystem is not None:
+            filesystem.rm(str(self), recursive=True)
+        else:
+            if self.is_hdfs:
+                with HDFSFileSystem() as hdfs:
+                    hdfs.rm(str(self), recursive=True)
+            else:
+                shutil.rmtree(str(self))
+
     def delete(self, filesystem: FileSystem = None):
         """Delete file from filesystem"""
         if not self.is_file(filesystem=filesystem):

--- a/deepr/jobs/copy_dir.py
+++ b/deepr/jobs/copy_dir.py
@@ -12,15 +12,19 @@ LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class CopyDir(base.Job):
-    """Copy Directory"""
+    """Copy Directory. Overwrite destination by default"""
 
     source: str
     target: str
     skip_copy: bool = False
+    overwrite: bool = True
 
     def run(self):
         if self.skip_copy:
             LOGGER.info(f"NOT COPYING {self.source} to {self.target} (skip_copy=True)")
             return
+        if self.overwrite_destination_folder and Path(self.target).is_dir():
+            Path(self.target).delete_dir()
+
         LOGGER.info(f"Copying {self.source} to {self.target}")
         Path(self.source).copy_dir(self.target)

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -15,6 +15,8 @@ Doctest run in CI.
 
 Changed
 ~~~~~~~
+copy_dir job will now overwrite the target by default
+
 Deprecated
 ~~~~~~~~~~
 Removed


### PR DESCRIPTION
# Description

add a delete_dir function in path.py and use it in copy_dir to overwrite the target directory by default

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Release


## Checklist

- [x] I have followed the [CONTRIBUTING](https://github.com/criteo/deepr/blob/master/docs/CONTRIBUTING.rst) guidelines.
- [x] I have updated the [CHANGELOG](https://github.com/criteo/deepr/blob/master/docs/CHANGELOG.rst).
