### PR TITLE
Yield inputs when using predictor on dataset

### DIFF
--- a/deepr/predictors/base.py
+++ b/deepr/predictors/base.py
@@ -54,7 +54,8 @@ class Predictor(abc.ABC):
                     try:
                         while True:
                             input_dict = self.session.run(next_element)
-                            yield self.__call__(input_dict)
+                            output_dict = self.__call__(input_dict)
+                            yield {**input_dict, **output_dict}
                     except tf.errors.OutOfRangeError:
                         pass
 

--- a/deepr/version.py
+++ b/deepr/version.py
@@ -1,4 +1,4 @@
 # pylint: disable=all
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __author__ = "Criteo"

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,24 @@ Fixed
 Security
 ~~~~~~~~
 
+[2.1.1] - 2020-06-05
+--------------------
+
+Added
+~~~~~
+- Predictors also yield inputs when applied on a ``tf.data.Dataset``
+
+Changed
+~~~~~~~
+Deprecated
+~~~~~~~~~~
+Removed
+~~~~~~~
+Fixed
+~~~~~
+Security
+~~~~~~~~
+
 
 [2.1.0] - 2020-06-04
 --------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = "2020, Criteo"
 author = "Criteo"
 
 # The full version, including alpha/beta/rc tags
-release = "2.0.0"
+release = "2.1.1"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
# Description

If predictor is used on a dataset, user has no access to the input values.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Release


## Checklist

- [x] I have followed the [CONTRIBUTING](https://github.com/criteo/deepr/blob/master/docs/CONTRIBUTING.rst) guidelines.
- [x] I have updated the [CHANGELOG](https://github.com/criteo/deepr/blob/master/docs/CHANGELOG.rst).
