### PR TITLE
Make arrays_to_example function importable

### DIFF
--- a/deepr/prepros/__init__.py
+++ b/deepr/prepros/__init__.py
@@ -4,4 +4,4 @@ from deepr.prepros.base import Prepro, PreproFn, prepro
 from deepr.prepros.combinators import Serial
 from deepr.prepros.core import Map, Filter, PaddedBatch, Shuffle, Repeat, Prefetch, Take, Batch, Cache
 from deepr.prepros.lookup import TableInitializer
-from deepr.prepros.record import TFRecordSequenceExample, FromExample, ToExample
+from deepr.prepros.record import TFRecordSequenceExample, FromExample, ToExample, arrays_to_example


### PR DESCRIPTION
# Description

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Release


## Checklist

- [ ] I have followed the [CONTRIBUTING](https://github.com/criteo/deepr/blob/master/docs/CONTRIBUTING.rst) guidelines.
- [ ] I have updated the [CHANGELOG](https://github.com/criteo/deepr/blob/master/docs/CHANGELOG.rst).
